### PR TITLE
Senker reserverte resurser basert på metrikker for dittnav

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -29,5 +29,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "200m"
       memory: 512Mi

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -29,5 +29,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "200m"
       memory: 512Mi


### PR DESCRIPTION
Siden DittNav har pus-decorator så er det litt vanskelig å vite hva den reelle ressursbruken kommer til å ligge på. For å være defensiv så tar jeg utgangspunkt i metrikkene fra DittNav, også kan vi sikkert justere det etterhvert som denne appen får trafikk.